### PR TITLE
Fixed closing the clocsql file

### DIFF
--- a/grepbugs.py
+++ b/grepbugs.py
@@ -158,7 +158,7 @@ def local_scan(srcdir, repo='none', account='local_scan', project='none', defaul
 		f = open(clocsql, 'r')
 		cur.executescript(f.read())
 		db.commit()
-		f.close
+		f.close()
 		os.remove(clocsql)
 
 	except Exception as e:


### PR DESCRIPTION
Braces were missing, so the file was not closed and Windows triggers an exception when the file is being removed.
